### PR TITLE
publish 1.0.1b4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,8 +122,8 @@ jobs:
             git config --global user.name "matthewhanson"
             git add -f gippy/algorithms.py gippy/algorithms_wrap.cpp gippy/gippy.py gippy/gippy_wrap.cpp
             git commit -a -m 'added swig wrappers for publishing to PyPi'
-            git tag v$VERSION
-            git push origin v$VERSION
+            git tag $VERSION
+            git push origin $VERSION
             python setup.py sdist
             pip install twine
             twine upload --username "${PYPI_USER}" --password "${PYPI_PASS}" dist/*


### PR DESCRIPTION
drops leading v in version tag which was causing a problem with tagging it with
git tag v$VERSION
which git doesn't like combining letters with envvars apparently