### PR TITLE
Performance tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ gippy/gippy.py
 gippy/gippy_wrap.cpp
 gippy/algorithms.py
 gippy/algorithms_wrap.cpp
+/.vs

--- a/GIP/GeoImage.cpp
+++ b/GIP/GeoImage.cpp
@@ -50,7 +50,7 @@ namespace gip {
     // Copy constructor
     GeoImage::GeoImage(const GeoImage& image)
         : GeoResource(image) {
-        for (uint i=0;i<image.nbands();i++)
+        for (unsigned int i=0;i<image.nbands();i++)
             _RasterBands.push_back( image[i] );
             _BandNames = image.bandnames();
     }
@@ -61,7 +61,7 @@ namespace gip {
         if (this == &image) return *this;
         GeoResource::operator=(image);
         _RasterBands.clear();
-        for (uint i=0;i<image.nbands();i++) _RasterBands.push_back( image[i] );
+        for (unsigned int i=0;i<image.nbands();i++) _RasterBands.push_back( image[i] );
         _BandNames = image.bandnames();
         return *this;
     }

--- a/GIP/GeoRaster.cpp
+++ b/GIP/GeoRaster.cpp
@@ -88,7 +88,7 @@ namespace gip {
         vector<Chunk>::const_iterator iCh;
         vector<Chunk> _chunks = chunks();
 
-		double noDataVal = nodata();
+        double noDataVal = nodata();
         for (iCh=_chunks.begin(); iCh!=_chunks.end(); iCh++) {
             cimg = read<double>(*iCh);
             cimg_for(cimg,ptr,double) {
@@ -281,7 +281,7 @@ namespace gip {
             char* wkt;
             site_t->exportToWkt(&wkt);
             psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions,"CUTLINE", wkt);
-			CPLFree(wkt);
+            CPLFree(wkt);
         }
 
         // set options

--- a/GIP/GeoRaster.cpp
+++ b/GIP/GeoRaster.cpp
@@ -280,6 +280,7 @@ namespace gip {
             char* wkt;
             site_t->exportToWkt(&wkt);
             psWarpOptions->papszWarpOptions = CSLSetNameValue(psWarpOptions->papszWarpOptions,"CUTLINE", wkt);
+			CPLFree(wkt);
         }
 
         // set options

--- a/GIP/GeoRaster.cpp
+++ b/GIP/GeoRaster.cpp
@@ -88,10 +88,11 @@ namespace gip {
         vector<Chunk>::const_iterator iCh;
         vector<Chunk> _chunks = chunks();
 
+		double noDataVal = nodata();
         for (iCh=_chunks.begin(); iCh!=_chunks.end(); iCh++) {
             cimg = read<double>(*iCh);
             cimg_for(cimg,ptr,double) {
-                if (*ptr != nodata()) {
+                if (*ptr != noDataVal) {
                     total += *ptr;
                     count++;
                     if (*ptr > max) max = *ptr;
@@ -105,7 +106,7 @@ namespace gip {
         for (iCh=_chunks.begin(); iCh!=_chunks.end(); iCh++) {
             cimg = read<double>(*iCh);
             cimg_for(cimg,ptr,double) {
-                if (*ptr != nodata()) {
+                if (*ptr != noDataVal) {
                     val = *ptr-mean;
                     total += (val*val);
                     total3 += (val*val*val);

--- a/GIP/GeoResource.cpp
+++ b/GIP/GeoResource.cpp
@@ -103,6 +103,7 @@ namespace gip {
             bbox.y1(), 0.0, -std::abs(bbox.height() / (float)ysz)  
         );
         set_affine(affine);
+		CSLDestroy(papszOptions);
     }
 
     GeoResource::GeoResource(const GeoResource& resource)

--- a/GIP/GeoResource.cpp
+++ b/GIP/GeoResource.cpp
@@ -103,7 +103,7 @@ namespace gip {
             bbox.y1(), 0.0, -std::abs(bbox.height() / (float)ysz)  
         );
         set_affine(affine);
-		CSLDestroy(papszOptions);
+        CSLDestroy(papszOptions);
     }
 
     GeoResource::GeoResource(const GeoResource& resource)

--- a/GIP/GeoVectorResource.cpp
+++ b/GIP/GeoVectorResource.cpp
@@ -22,6 +22,7 @@
 #include <gip/GeoVectorResource.h>
 
 #include <iostream>
+#include <functional>
 
 #include <cpl_error.h>
 
@@ -93,10 +94,12 @@ namespace gip {
        return *_Layer->GetSpatialRef();
     }*/
 
-    std::string GeoVectorResource::srs() const {
-        char* wkt(NULL);
+    std::string GeoVectorResource::srs() const {  
+		auto deleter = [](char* p) {CPLFree(p); };
+		char* wkt(NULL);
         _Layer->GetSpatialRef()->exportToWkt(&wkt);
-        return std::string(wkt); 
+		std::unique_ptr<char, decltype(deleter)> wktPtr(wkt, deleter); //make sure the char* is freed.
+        return std::string(wkt); //char* is copied
     }
 
     BoundingBox GeoVectorResource::extent() const {

--- a/GIP/GeoVectorResource.cpp
+++ b/GIP/GeoVectorResource.cpp
@@ -95,10 +95,10 @@ namespace gip {
     }*/
 
     std::string GeoVectorResource::srs() const {  
-		auto deleter = [](char* p) {CPLFree(p); };
-		char* wkt(NULL);
+        auto deleter = [](char* p) {CPLFree(p); };
+        char* wkt(NULL);
         _Layer->GetSpatialRef()->exportToWkt(&wkt);
-		std::unique_ptr<char, decltype(deleter)> wktPtr(wkt, deleter); //make sure the char* is freed.
+        std::unique_ptr<char, decltype(deleter)> wktPtr(wkt, deleter); //make sure the char* is freed.
         return std::string(wkt); //char* is copied
     }
 

--- a/GIP/gip/GeoRaster.h
+++ b/GIP/gip/GeoRaster.h
@@ -515,7 +515,7 @@ namespace gip {
         // If processing was applied update NoData values where needed
         if (updatenodata) {
             cimg_forXY(img,x,y) {
-                if (imgorig(x,y) == nodata() || std::isinf(imgorig(x,y)) || std::isnan(imgorig(x,y)))
+                if (imgorig(x,y) == nodata() || (std::is_floating_point<T>::value && (std::isinf(imgorig(x,y)) || std::isnan(imgorig(x,y)))))
                     img(x,y) = nodata();
             }
         }

--- a/GIP/gip/GeoRaster.h
+++ b/GIP/gip/GeoRaster.h
@@ -494,7 +494,8 @@ namespace gip {
         bool updatenodata = false;
         // Apply gain and offset
         if ((gain() != 1.0 || offset() != 0.0) && (!nogainoff)) {
-            img = gain() * img + offset();
+			img *= gain();
+			img += offset();
             // Update NoData now so applied functions have proper NoData value set (?)
             updatenodata = true;
         }
@@ -514,9 +515,11 @@ namespace gip {
 
         // If processing was applied update NoData values where needed
         if (updatenodata) {
+			T noDataVal = static_cast<T>(nodata());
             cimg_forXY(img,x,y) {
-                if (imgorig(x,y) == nodata() || (std::is_floating_point<T>::value && (std::isinf(imgorig(x,y)) || std::isnan(imgorig(x,y)))))
-                    img(x,y) = nodata();
+				T sample = imgorig(x, y);
+                if (sample == noDataVal || (std::is_floating_point<T>::value && (std::isinf(sample) || std::isnan(sample))))
+                    img(x,y) = noDataVal;
             }
         }
         auto elapsed = std::chrono::duration_cast<std::chrono::duration<float> >(std::chrono::system_clock::now()-start);

--- a/GIP/gip/GeoRaster.h
+++ b/GIP/gip/GeoRaster.h
@@ -558,7 +558,15 @@ namespace gip {
     //! Write a Cimg to the file
     template<class T> GeoRaster& GeoRaster::write(CImg<T> img, Chunk chunk) {
         if (gain() != 1.0 || offset() != 0.0) {
-            cimg_for(img,ptr,T) if (*ptr != nodata()) *ptr = (*ptr-offset())/gain();
+			double noDataVal = nodata(); //virtual call through pointer
+			double offsetVal = offset(); //virtual call through pointer
+			double invGainVal = 1.0 / gain(); //virtual call through pointer
+			cimg_for(img, ptr, T) { 
+				double sample = static_cast<double>(*ptr);
+				if (sample != noDataVal) { 
+					*ptr = static_cast<T>((sample - offsetVal) * invGainVal); 
+				}
+			}
         }
         if (Options::verbose() > 3 && (chunk.p0()==iPoint(0,0)))
             std::cout << basename() << ": Writing (" << gain() << "x + " << offset() << ")" << std::endl;

--- a/GIP/gip/GeoRaster.h
+++ b/GIP/gip/GeoRaster.h
@@ -494,8 +494,8 @@ namespace gip {
         bool updatenodata = false;
         // Apply gain and offset
         if ((gain() != 1.0 || offset() != 0.0) && (!nogainoff)) {
-			img *= gain();
-			img += offset();
+            img *= gain();
+            img += offset();
             // Update NoData now so applied functions have proper NoData value set (?)
             updatenodata = true;
         }
@@ -515,9 +515,9 @@ namespace gip {
 
         // If processing was applied update NoData values where needed
         if (updatenodata) {
-			T noDataVal = static_cast<T>(nodata());
+            T noDataVal = static_cast<T>(nodata());
             cimg_forXY(img,x,y) {
-				T sample = imgorig(x, y);
+                T sample = imgorig(x, y);
                 if (sample == noDataVal || (std::is_floating_point<T>::value && (std::isinf(sample) || std::isnan(sample))))
                     img(x,y) = noDataVal;
             }
@@ -561,15 +561,15 @@ namespace gip {
     //! Write a Cimg to the file
     template<class T> GeoRaster& GeoRaster::write(CImg<T> img, Chunk chunk) {
         if (gain() != 1.0 || offset() != 0.0) {
-			double noDataVal = nodata(); //virtual call through pointer
-			double offsetVal = offset(); //virtual call through pointer
-			double invGainVal = 1.0 / gain(); //virtual call through pointer
-			cimg_for(img, ptr, T) { 
-				double sample = static_cast<double>(*ptr);
-				if (sample != noDataVal) { 
-					*ptr = static_cast<T>((sample - offsetVal) * invGainVal); 
-				}
-			}
+            double noDataVal = nodata(); //virtual call through pointer
+            double offsetVal = offset(); //virtual call through pointer
+            double invGainVal = 1.0 / gain(); //virtual call through pointer
+            cimg_for(img, ptr, T) { 
+                double sample = static_cast<double>(*ptr);
+                if (sample != noDataVal) { 
+                    *ptr = static_cast<T>((sample - offsetVal) * invGainVal); 
+                }
+            }
         }
         if (Options::verbose() > 3 && (chunk.p0()==iPoint(0,0)))
             std::cout << basename() << ": Writing (" << gain() << "x + " << offset() << ")" << std::endl;

--- a/GIP/gip/GeoResource.h
+++ b/GIP/gip/GeoResource.h
@@ -106,6 +106,7 @@ namespace gip {
             char* prj;
             oSRS.exportToWkt(&prj);
             _GDALDataset->SetProjection(prj);
+			CPLFree(prj);
             //OGRSpatialReference::DestroySpatialReference(oSRS);
             return *this;
         }

--- a/GIP/gip/GeoResource.h
+++ b/GIP/gip/GeoResource.h
@@ -106,7 +106,7 @@ namespace gip {
             char* prj;
             oSRS.exportToWkt(&prj);
             _GDALDataset->SetProjection(prj);
-			CPLFree(prj);
+            CPLFree(prj);
             //OGRSpatialReference::DestroySpatialReference(oSRS);
             return *this;
         }
@@ -122,7 +122,7 @@ namespace gip {
             _GDALDataset->SetGeoTransform(affine.data());
             return *this;
         }
-	/* remove for now, add back in when required, with tests
+    /* remove for now, add back in when required, with tests
         GeoResource& SetGCPs(CImg<double> gcps, std::string projection) {
             int numgcps(gcps.height());
             GDAL_GCP gdal_gcps[numgcps];


### PR DESCRIPTION

[opt_benchmark.txt](https://github.com/gipit/gippy/files/2336673/opt_benchmark.txt)


This script runs about twice as fast.
```
import gippy as gp
import gippy.algorithms as alg

def main():
    gp.Options.set_chunksize(0.5)

    filenames = ['landsat_green.TIF', 'landsat_nir.TIF']
    bandnames = ['green', 'nir']

    geoimg = gp.GeoImage(filenames)
    geoimg.set_bandnames(bandnames)
    geoimg.set_nodata(0)
    
    outImg = alg.indices(geoimg, ['ndwi'], './ndwi_algs.tif')
    histogram = outImg[0].histogram(500)

if __name__ == "__main__":
   main()
```