### PR TITLE
fix(chunks): using numchunks didn't cover image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
       - run: |
             yum install -y swig
             . ~/venv27/bin/activate
-            pip install . --no-cache
+            pip install -e . --no-cache
             cd test
             pytest --cov gippy     
 

--- a/GIP/GeoResource.cpp
+++ b/GIP/GeoResource.cpp
@@ -202,7 +202,7 @@ namespace gip {
             rows = rows > ysize() ? ysize() : rows;
             numchunks = ceil( ysize()/(float)rows );
         } else {
-            rows = int(ysize() / numchunks);
+            rows = ceil(ysize() / (float)numchunks);
         }
 
         _Chunks.clear();

--- a/test/test_GeoResource.py
+++ b/test/test_GeoResource.py
@@ -115,14 +115,24 @@ class GeoResourceTests(unittest.TestCase):
         self.assertEqual(len(chunks), 1)
         self.assertEqual(chunks[0].width(), geoimg.xsize())
         self.assertEqual(chunks[0].height(), geoimg.ysize())
-        # test with 100 chunks
-        chunks = geoimg.chunks(numchunks=100)
+        # test with 11 chunks
+        chunks = geoimg.chunks(numchunks=11)
         # test height of chunks is the same (except last one)
-        self.assertEqual(len(chunks), 100)
+        self.assertEqual(len(chunks), 11)
         for i in range(1, len(chunks)-1):
             self.assertEqual(chunks[i].height(), chunks[i-1].height())
             self.assertEqual(chunks[i].width(), geoimg.xsize())
             self.assertEqual(chunks[i].y0(), chunks[i-1].y1())
+        self.assertNotEqual(chunks[-1].height(), chunks[-2].height())
+        # test with 10 chunks
+        chunks = geoimg.chunks(numchunks=10)
+        # test height of chunks is the same (including last one)
+        self.assertEqual(len(chunks), 10)
+        for i in range(1, len(chunks)):
+            self.assertEqual(chunks[i].height(), chunks[i-1].height())
+            self.assertEqual(chunks[i].width(), geoimg.xsize())
+            self.assertEqual(chunks[i].y0(), chunks[i-1].y1())
+
 
     def test_meta(self):
         """ Set and retrieve metadata """


### PR DESCRIPTION
I believe this is straight forward -- found in 0.3.x branch, and also exists in mainline development.

I hope the expansion/tweaks to the chunking test make sense to cover the cases.  The previous `test_GeoResource.test_chunking` didn't actually assert about the final chunk.

:+1: to @justinfisk for the help in sorting this out on the 0.3.x branch.